### PR TITLE
PHI Annotation + Unionization Logic

### DIFF
--- a/flaskdeid/annotation.py
+++ b/flaskdeid/annotation.py
@@ -1,0 +1,110 @@
+"""Module for standardizing and combining annotations"""
+class Annotation(object):
+    def __init__(self, origin):
+        self.origin = origin
+        self.start = None
+        self.end = None
+        self.score = None
+        self.type = None
+        self.text = None
+
+    def empty(self):
+        return not (self.start and self.end and self.text)
+
+    def from_medlp(medlp):
+        ann = Annotation('medlp')
+        ann.start = medlp.get('BeginOffset')
+        ann.end = medlp.get('EndOffset')
+        ann.score = medlp.get('Score')
+        ann.type = medlp.get('Type')
+        ann.text = medlp.get('Text')
+        return ann
+
+    def from_hutchner(hutchner):
+        ann = Annotation('hutchner')
+        ann.start = hutchner.get('start')
+        ann.end = hutchner.get('stop')
+        ann.score = hutchner.get('confidence')
+        ann.type = hutchner.get('label')
+        ann.text = hutchner.get('text')
+        return ann
+
+    def to_dict(self):
+        data = {}
+        data['origin'] = self.origin
+        data['start'] = self.start
+        data['end'] = self.end
+        data['score'] = self.score
+        data['type'] = self.type
+        data['text'] = self.text
+        return data
+
+
+class MergedAnnotation(Annotation):
+    def __init__(self):
+        super().__init__('merged')
+        self.source_annotations = []
+
+    @property
+    def source_types(self):
+        return set([ann.type for ann in self.source_annotations])
+
+    @property
+    def source_scores(self):
+        return [ann.score for ann in self.source_annotations]
+
+    @property
+    def source_origins(self):
+        return set([ann.origin for ann in self.source_annotations])
+
+    def add_annotation(self, ann):
+        if ann.empty():
+            raise ValueError("new annotation cannot be empty")
+        if self.empty():
+            self.text = ann.text
+            self.start = ann.start
+            self.end = ann.end
+            self.type = ann.type
+        else:
+            if (self.start <= ann.start):
+                self.text = self.text + ann.text[(self.end-ann.start):]
+            else:
+                self.text = ann.text + self.text[(ann.end-self.start):]
+            self.start = min([self.start, ann.start])
+            self.end = max([self.end, ann.end])
+            self.type = "Unknown" if (self.type != ann.type) else self.type
+        self.source_annotations.append(ann)
+
+    def from_annotations(anns):
+        if not anns:
+            raise ValueError("annotation list cannot be empty")
+        merged = MergedAnnotation()
+        for ann in anns:
+            merged.add_annotation(ann)
+        return merged
+
+    def to_dict(self, detailed=False):
+        data = super().to_dict()
+        data['source_types'] = self.source_types
+        data['source_scores'] = self.source_scores
+        data['source_origins'] = self.source_origins
+        if detailed:
+            data['source_annotations'] = [ann.to_dict() for ann in self.source_annotations]
+        return data
+
+
+def unionize_annotations(annotations):
+    sorted_anns = sorted(annotations, key=lambda x: x.start)
+    final_anns = []
+    current_anns = []
+    for idx in range(0, max([ann.end for ann in annotations])):
+        # check if current annotations end at idx
+        if current_anns and all((ann.end <= idx) for ann in current_anns):
+            final_anns.append(MergedAnnotation.from_annotations(current_anns))
+            current_anns = []
+        # get all new annotations at idx
+        while sorted_anns and (sorted_anns[0].start == idx):
+            current_anns.append(sorted_anns.pop(0))
+    if current_anns:
+        final_anns.append(MergedAnnotation.from_annotations(current_anns))
+    return final_anns

--- a/flaskdeid/deid.py
+++ b/flaskdeid/deid.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from annotation import Annotation, unionize_annotations
+from annotation import Annotation, AnnotationFactory, unionize_annotations
 from flask import Blueprint, render_template, request, session, abort, jsonify, Response, current_app, g
 from flaskdeid import medlpInterface
 import hutchner
@@ -16,8 +16,8 @@ bp = Blueprint('deid', __name__, url_prefix='/deid')
 @bp.route("/annotate", methods=['POST'])
 def identify_phi(**kwargs):
     annotations = []
-    annotations += [Annotation.from_medlp(phi) for phi in medlp.annotate_phi(**kwargs)]
-    annotations += [Annotation.from_hutchner(phi) for phi in hutchner.annotate_phi(**kwargs)]
+    annotations += [AnnotationFactory.from_medlp(phi) for phi in medlp.annotate_phi(**kwargs)]
+    annotations += [AnnotationFactory.from_hutchner(phi) for phi in hutchner.annotate_phi(**kwargs)]
     merged_results = unionize_annotations(annotations)
     return Response(json.dumps([res.to_dict() for res in merged_results]),
                     mimetype=u'application/json')

--- a/flaskdeid/deid.py
+++ b/flaskdeid/deid.py
@@ -19,7 +19,8 @@ def identify_phi(**kwargs):
     annotations += [Annotation.from_medlp(phi) for phi in medlp.annotate_phi(**kwargs)]
     annotations += [Annotation.from_hutchner(phi) for phi in hutchner.annotate_phi(**kwargs)]
     merged_results = unionize_annotations(annotations)
-    return Response(json.dumps(merged_results), mimetype=u'application/json')
+    return Response(json.dumps([res.to_dict() for res in merged_results]),
+                    mimetype=u'application/json')
 
 @bp.route("/resynthesize", methods=['POST'])
 def resynthesize_text(**kwargs):

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     url='https://github.com/WhiteAu/FlaskML',
     install_requires=['hdc_preprocessing',
                       'amazonserviceinterface',
+                      'HutchNERPredict',
                       'sectionerex',
                       'flask',
                       'boto3',
@@ -50,6 +51,8 @@ setup(
     dependency_links = ['https://{}@github.com/FredHutch/hdc-preprocessing/tarball/master#egg=hdc_preprocessing'
                             .format(get_env_variable('HDCGITAUTHTOKEN')),
                         "https://{}@github.com/FredHutch/HDCMedLPInterface/tarball/master#egg=amazonserviceinterface"
+                            .format(get_env_variable('HDCGITAUTHTOKEN')),
+                        "https://{}@github.com/FredHutch/HutchNERPredict/tarball/master#egg=HutchNERPredict"
                             .format(get_env_variable('HDCGITAUTHTOKEN')),
                         "https://{}@github.com/FredHutch/SectionerEx/tarball/master#egg=sectionerex"
                             .format(get_env_variable('HDCGITAUTHTOKEN')),

--- a/test/flaskdeid/test_annotation.py
+++ b/test/flaskdeid/test_annotation.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from flaskdeid.annotation import Annotation, MergedAnnotation
+from flaskdeid.annotation import Annotation, AnnotationFactory, MergedAnnotation
 from flaskdeid.annotation import unionize_annotations
 
 
@@ -117,19 +117,19 @@ class AnnotationTest(TestCase):
     def test_annotation_empty(self):
         ann1 = Annotation('test')
         self.assertTrue(ann1.empty())
-        ann2 = Annotation.from_hutchner(self.sample_hutchner[0])
+        ann2 = AnnotationFactory.from_hutchner(self.sample_hutchner[0])
         self.assertFalse(ann2.empty())
 
     def test_annotation_from_medlp(self):
         for sample in self.sample_medlp:
-            ann = Annotation.from_medlp(sample)
+            ann = AnnotationFactory.from_medlp(sample)
             self.assertEqual(ann.origin, 'medlp')
             self.assertEqual(ann.text, sample['Text'])
             self.assertEqual(ann.start, sample['BeginOffset'])
 
     def test_annotation_from_hutchner(self):
         for sample in self.sample_hutchner:
-            ann = Annotation.from_hutchner(sample)
+            ann = AnnotationFactory.from_hutchner(sample)
             self.assertEqual(ann.origin, 'hutchner')
             self.assertEqual(ann.type, sample['label'])
             self.assertEqual(ann.score, sample['confidence'])
@@ -140,9 +140,9 @@ class AnnotationTest(TestCase):
         self.assertEqual(data['origin'], 'test')
 
     def test_mergedannotation_from_annotations(self):
-        ann1 = Annotation.from_medlp(self.sample_medlp[0])
-        ann2 = Annotation.from_hutchner(self.sample_hutchner[0])
-        merged = MergedAnnotation.from_annotations([ann1, ann2])
+        ann1 = AnnotationFactory.from_medlp(self.sample_medlp[0])
+        ann2 = AnnotationFactory.from_hutchner(self.sample_hutchner[0])
+        merged = AnnotationFactory.from_annotations([ann1, ann2])
         self.assertEqual(merged.origin, 'merged')
         self.assertEqual(merged.start, ann1.start)
         self.assertEqual(merged.end, ann2.end)
@@ -154,9 +154,9 @@ class AnnotationTest(TestCase):
         self.assertTrue(ann1 in merged.source_annotations)
 
     def test_mergedannotation_to_dict(self):
-        ann1 = Annotation.from_medlp(self.sample_medlp[0])
-        ann2 = Annotation.from_hutchner(self.sample_hutchner[0])
-        merged = MergedAnnotation.from_annotations([ann1, ann2])
+        ann1 = AnnotationFactory.from_medlp(self.sample_medlp[0])
+        ann2 = AnnotationFactory.from_hutchner(self.sample_hutchner[0])
+        merged = AnnotationFactory.from_annotations([ann1, ann2])
         data = merged.to_dict()
         self.assertEqual(data['origin'], 'merged')
         self.assertEqual(data['text'], 'Mr. John Smith Jr.')
@@ -165,13 +165,13 @@ class AnnotationTest(TestCase):
         self.assertEqual(len(detailed['source_annotations']), 2)
 
     def test_mergedannotation_invalid_cases(self):
-        self.assertRaises(ValueError, MergedAnnotation.from_annotations, [])
+        self.assertRaises(ValueError, AnnotationFactory.from_annotations, [])
         self.assertRaises(ValueError, MergedAnnotation().add_annotation,
                           Annotation('test'))
 
     def test_unionize_annotations(self):
-        anns = [Annotation.from_medlp(ann) for ann in self.sample_medlp]
-        anns += [Annotation.from_hutchner(ann) for ann in self.sample_hutchner]
+        anns = [AnnotationFactory.from_medlp(ann) for ann in self.sample_medlp]
+        anns += [AnnotationFactory.from_hutchner(ann) for ann in self.sample_hutchner]
         union = unionize_annotations(anns)
 
         self.assertEqual(len(union), 6)

--- a/test/flaskdeid/test_annotation.py
+++ b/test/flaskdeid/test_annotation.py
@@ -1,0 +1,182 @@
+from unittest import TestCase
+
+from flaskdeid.annotation import Annotation, MergedAnnotation
+from flaskdeid.annotation import unionize_annotations
+
+
+class AnnotationTest(TestCase):
+
+    def setUp(self):
+        # sample text
+        self.sample_text = ("Patient is Mr. John Smith Jr., a 48-year-old "
+            "teacher and chef. His phone number is (555) 867-5309, "
+            "and his address is 123 Sesame St, Seattle, WA 99999.")
+        # sample MedLP results
+        self.sample_medlp = [
+            {
+                "Id": 0,
+                "BeginOffset": 11,
+                "EndOffset": 25,
+                "Score": 0.99,
+                "Text": "Mr. John Smith",
+                "Category": "PROTECTED_HEALTH_INFORMATION",
+                "Type": "NAME",
+                "Traits": []
+            },
+            {
+                "Id": 1,
+                "BeginOffset": 33,
+                "EndOffset": 35,
+                "Score": 0.98,
+                "Text": "48",
+                "Category": "PROTECTED_HEALTH_INFORMATION",
+                "Type": "AGE",
+                "Traits": []
+            },
+            {
+                "Id": 2,
+                "BeginOffset": 45,
+                "EndOffset": 52,
+                "Score": 0.97,
+                "Text": "teacher",
+                "Category": "PROTECTED_HEALTH_INFORMATION",
+                "Type": "PROFESSION",
+                "Traits": []
+            },
+            {
+                "Id": 3,
+                "BeginOffset": 83,
+                "EndOffset": 97,
+                "Score": 0.96,
+                "Text": "(555) 867-5309",
+                "Category": "PROTECTED_HEALTH_INFORMATION",
+                "Type": "PHONE",
+                "Traits": []
+            },
+            {
+                "Id": 4,
+                "BeginOffset": 122,
+                "EndOffset": 144,
+                "Score": 0.95,
+                "Text": "Sesame St, Seattle, WA",
+                "Category": "PROTECTED_HEALTH_INFORMATION",
+                "Type": "ADDRESS",
+                "Traits": []
+            }
+        ]
+        # sample HutchNER results
+        self.sample_hutchner = [
+            {
+                "start": 15,
+                "stop": 29,
+                "confidence": 0.01,
+                "text": "John Smith Jr.",
+                "label": "NAME"
+            },
+            {
+                "start": 33,
+                "stop": 44,
+                "confidence": 0.02,
+                "text": "48-year-old",
+                "label": "AGE"
+            },
+            {
+                "start": 57,
+                "stop": 61,
+                "confidence": 0.03,
+                "text": "chef",
+                "label": "JOB"
+            },
+            {
+                "start": 89,
+                "stop": 97,
+                "confidence": 0.04,
+                "text": "867-5309",
+                "label": "PHONE"
+            },
+            {
+                "start": 118,
+                "stop": 131,
+                "confidence": 0.05,
+                "text": "123 Sesame St",
+                "label": "LOCATION"
+            },
+            {
+                "start": 142,
+                "stop": 150,
+                "confidence": 0.06,
+                "text": "WA 99999",
+                "label": "LOCATION"
+            }
+        ]
+
+
+    def tearDown(self):
+        pass
+
+    def test_annotation_empty(self):
+        ann1 = Annotation('test')
+        self.assertTrue(ann1.empty())
+        ann2 = Annotation.from_hutchner(self.sample_hutchner[0])
+        self.assertFalse(ann2.empty())
+
+    def test_annotation_from_medlp(self):
+        for sample in self.sample_medlp:
+            ann = Annotation.from_medlp(sample)
+            self.assertEqual(ann.origin, 'medlp')
+            self.assertEqual(ann.text, sample['Text'])
+            self.assertEqual(ann.start, sample['BeginOffset'])
+
+    def test_annotation_from_hutchner(self):
+        for sample in self.sample_hutchner:
+            ann = Annotation.from_hutchner(sample)
+            self.assertEqual(ann.origin, 'hutchner')
+            self.assertEqual(ann.type, sample['label'])
+            self.assertEqual(ann.score, sample['confidence'])
+
+    def test_annotation_to_dict(self):
+        ann = Annotation('test')
+        data = ann.to_dict()
+        self.assertEqual(data['origin'], 'test')
+
+    def test_mergedannotation_from_annotations(self):
+        ann1 = Annotation.from_medlp(self.sample_medlp[0])
+        ann2 = Annotation.from_hutchner(self.sample_hutchner[0])
+        merged = MergedAnnotation.from_annotations([ann1, ann2])
+        self.assertEqual(merged.origin, 'merged')
+        self.assertEqual(merged.start, ann1.start)
+        self.assertEqual(merged.end, ann2.end)
+        self.assertEqual(merged.text, "Mr. John Smith Jr.")
+
+        self.assertEqual(merged.source_origins,
+                         set([ann1.origin, ann2.origin]))
+        self.assertEqual(merged.source_scores, [ann1.score, ann2.score])
+        self.assertTrue(ann1 in merged.source_annotations)
+
+    def test_mergedannotation_to_dict(self):
+        ann1 = Annotation.from_medlp(self.sample_medlp[0])
+        ann2 = Annotation.from_hutchner(self.sample_hutchner[0])
+        merged = MergedAnnotation.from_annotations([ann1, ann2])
+        data = merged.to_dict()
+        self.assertEqual(data['origin'], 'merged')
+        self.assertEqual(data['text'], 'Mr. John Smith Jr.')
+        self.assertTrue('medlp' in data['source_origins'])
+        detailed = merged.to_dict(detailed=True)
+        self.assertEqual(len(detailed['source_annotations']), 2)
+
+    def test_mergedannotation_invalid_cases(self):
+        self.assertRaises(ValueError, MergedAnnotation.from_annotations, [])
+        self.assertRaises(ValueError, MergedAnnotation().add_annotation,
+                          Annotation('test'))
+
+    def test_unionize_annotations(self):
+        anns = [Annotation.from_medlp(ann) for ann in self.sample_medlp]
+        anns += [Annotation.from_hutchner(ann) for ann in self.sample_hutchner]
+        union = unionize_annotations(anns)
+
+        self.assertEqual(len(union), 6)
+        for merged in union:
+            self.assertEqual(merged.text,
+                             self.sample_text[merged.start:merged.end])
+        self.assertEqual(len(union[5].source_annotations), 3)
+        self.assertEqual(len(union[5].source_origins), 2)


### PR DESCRIPTION
* added Annotation class
  * provides standardized object for annotation comparison
* added MergedAnnotation subclass
  * stores groups of related Annotation objects
    * follows specific logic for text combination and type inference
    * retains data from all original annotations
* added AnnotationFactory
  * allows creation of Annotations from different origin sources (currently hutcher, medlp)
  * allows creation of MergedAnnotations from multiple Annotations
* added `unionize_annotations()` method, to split large Annotation lists into like-groups, and merge those like-groups into MergedAnnotation objects
* updated `/deid/annotate` endpoint, to use new `unionize_annotations()` method
* defined hutchner->medlp mapping for mismatch cases
* added extensive unit tests for all Annotation-related logic