### PR TITLE
Updating type mapping & logic

### DIFF
--- a/flaskdeid/annotation.py
+++ b/flaskdeid/annotation.py
@@ -165,7 +165,7 @@ class MergedAnnotation(Annotation):
                 self.text = ann.text + self.text[(ann.end-self.start):]
             self.start = min([self.start, ann.start])
             self.end = max([self.end, ann.end])
-            self.type_map = {**ann.type_map, **self.type_map}
+            self.type_map = self.type_map or ann.type_map
         self.source_annotations.append(ann)
 
     def to_dict(self, detailed=False):


### PR DESCRIPTION
* updated hutchner -> medlp type mapping with newest hutchner model labels
* modified MergedAnnotation `.type` and `.score` properties
   * previously, `.score` was just empty, and `.type` just pulled the matching type property of all the source annotations (`.type` if all matched, else `.parent_type` if all matched, else `UNKNOWN`)
   * now, uses the following logic:
      * if all source types match, use that type, and the max score
      * else if all source parent types match:
         * if the source annotation with the highest score is above the `TYPE_THRESHOLD`, use that annotation's type and score
         * else use the matching parent type, with the highest scoring annotation's score
      * else the type is `UNKNOWN` and the score is the `TYPE_THRESHOLD` (default 0.5)
* added error handling if merge is attempted on non-overlapping annotations
* updated annotation unit tests to check all the above logic, and to use the newest hutchner types