### PR TITLE
updated label mapping

### DIFF
--- a/flaskdeid/annotation.py
+++ b/flaskdeid/annotation.py
@@ -1,22 +1,15 @@
 """Module for standardizing and combining annotations"""
 from operator import attrgetter
 
-# TODO: If more origins/mappings added, rip this out into separate json file
+# map hutchner labels to appriate comp med labels
 HUTCHNER_TYPE_MAP = {
-    "WARD_NAME": "ADDRESS",
-    "URL_OR_IP": "URL",
-    "BIOMETRIC_IDENTIFIER": "ID",
-    "PHI_OTHER": "UNKNOWN",
-    "EMPLOYER": "PROFESSION",
-    "PATIENT_OR_FAMILY_NAME": "NAME",
+    "WARD": "ADDRESS",
+    "SPECIALTY":"ADDRESS",
     "HOSPITAL_NAME": "ADDRESS",
     "MEDICAL_RECORD_NUMBER": "ID",
-    "ADDRESS_AND_COMPONENTS": "ADDRESS",
-    "PHONE_NUMBER": "PHONE_OR_FAX",
+    "PATIENT_OR_FAMILY_NAME": "NAME",
     "PROVIDER_NAME": "NAME",
-    "CERTIFICATE_OR_LICENSE_NUMBER": "ID",
-    "ACCOUNT_NUMBER": "ID",
-    "VEHICLE_OR_DEVICE_NUMBER": "ID"
+    "EMPLOYER": "PROFESSION"
 }
 TYPE_THRESHOLD = 0.5
 


### PR DESCRIPTION
updating deid label mapping from HutchNER to CompMed labels to reflect retraining
- standardization of common tags
- addition of 'specialty' tags in order to white list general clinical groups and facilities


labels can be double checked against the new 'phi_v2_w_specialties' model in the DataScience shared folder - NLP/DeIdPipeline/NERResources/Models