### PR TITLE
Parent to child subtype merging

### DIFF
--- a/flaskphiid/annotation.py
+++ b/flaskphiid/annotation.py
@@ -13,6 +13,13 @@ HUTCHNER_TYPE_MAP = {
 }
 TYPE_THRESHOLD = 0.5
 
+class IncompatibleTypeException(Exception):
+    def __init__(self, message, type_set):
+        additional_info = "previous types: {type_set}".format(type_set=type_set)
+        full_message = ":\n ".join([message, additional_info])
+        super(IncompatibleTypeException, self).__init__(full_message)
+        self.type_set = type_set
+
 
 class AnnotationFactory:
 
@@ -47,7 +54,20 @@ class AnnotationFactory:
         merged = MergedAnnotation()
         for ann in anns:
             merged.add_annotation(ann)
-        return merged
+        if merged.has_compatible_family_typelist:
+            return merged.split_annotations_by_subtypes()
+
+        return [merged]
+
+    @staticmethod
+    def from_unsplittable_annotations(anns):
+        if not anns:
+            raise ValueError("annotation list cannot be empty")
+        merged = MergedAnnotation()
+        for ann in anns:
+            merged.add_annotation(ann)
+
+        return [merged]
 
 
 class Annotation(object):
@@ -126,6 +146,10 @@ class MergedAnnotation(Annotation):
         pass
 
     @property
+    def has_compatible_family_typelist(self):
+        return self.type != 'UNKNOWN'
+
+    @property
     def score(self):
         if len(self.source_types) == 1:
             return max([x.score for x in self.source_annotations])
@@ -161,6 +185,26 @@ class MergedAnnotation(Annotation):
             self.type_map = self.type_map or ann.type_map
         self.source_annotations.append(ann)
 
+    def split_annotations_by_subtypes(self):
+        if len(self.source_types) == 1:
+            return self.source_annotations
+
+        if len(self.source_parent_types) == 1:
+            subtypes = [x for x in self.source_annotations if (x.type != x.parent_type)]
+            subtyped_annotations = []
+            running_annos = []
+            for anno in self.source_annotations:
+                if not running_annos or anno.type == running_annos[-1].type:
+                    running_annos.append(anno)
+                    continue
+                subtyped_annotations.extend(AnnotationFactory.from_unsplittable_annotations(running_annos))
+                running_annos = [anno]
+            subtyped_annotations.extend(AnnotationFactory.from_unsplittable_annotations(running_annos))
+
+            return subtyped_annotations
+
+        raise IncompatibleTypeException("Cannot split by subtype for multiple parent types", self.source_parent_types)
+
     def to_dict(self, detailed=False):
         data = super().to_dict()
         data['source_types'] = list(self.source_types)
@@ -180,11 +224,11 @@ def unionize_annotations(annotations):
     for idx in range(0, max([ann.end for ann in annotations])):
         # check if current annotations end at idx
         if current_anns and all((ann.end <= idx) for ann in current_anns):
-            final_anns.append(AnnotationFactory.from_annotations(current_anns))
+            final_anns.extend(AnnotationFactory.from_annotations(current_anns))
             current_anns = []
         # get all new annotations at idx
         while sorted_anns and (sorted_anns[0].start == idx):
             current_anns.append(sorted_anns.pop(0))
     if current_anns:
-        final_anns.append(AnnotationFactory.from_annotations(current_anns))
+        final_anns.extend(AnnotationFactory.from_annotations(current_anns))
     return final_anns

--- a/flaskphiid/annotation.py
+++ b/flaskphiid/annotation.py
@@ -54,7 +54,7 @@ class AnnotationFactory:
         merged = MergedAnnotation()
         for ann in anns:
             merged.add_annotation(ann)
-        if merged.has_compatible_family_typelist:
+        if merged.is_unknown_type:
             return merged.split_annotations_by_subtypes()
 
         return [merged]
@@ -146,7 +146,7 @@ class MergedAnnotation(Annotation):
         pass
 
     @property
-    def has_compatible_family_typelist(self):
+    def is_unknown_type(self):
         return self.type != 'UNKNOWN'
 
     @property
@@ -187,7 +187,7 @@ class MergedAnnotation(Annotation):
 
     def split_annotations_by_subtypes(self):
         if len(self.source_types) == 1:
-            return self.source_annotations
+            return [self]
 
         if len(self.source_parent_types) == 1:
             subtypes = [x for x in self.source_annotations if (x.type != x.parent_type)]

--- a/test/flaskphiid/test_annotation.py
+++ b/test/flaskphiid/test_annotation.py
@@ -341,7 +341,7 @@ class AnnotationTest(TestCase):
         anns += [AnnotationFactory.from_hutchner(ann) for ann in self.sample_hutchner]
         union = unionize_annotations(anns)
 
-        self.assertEqual(len(union), 11)
+        self.assertEqual(len(union), 10)
         for merged in union:
             self.assertEqual(merged.text,
                              self.sample_text[merged.start:merged.end])
@@ -369,7 +369,7 @@ class AnnotationTest(TestCase):
         anns += [AnnotationFactory.from_hutchner(self.sample_hutchner[6])]
         sorted_anns = sorted(anns, key=lambda x: x.start)
         merged = MergedAnnotation()
-        for ann in anns:
+        for ann in sorted_anns:
             merged.add_annotation(ann)
         self.assertEqual(merged.type, "UNKNOWN")
         with self.assertRaises(IncompatibleTypeException) as context:
@@ -377,5 +377,24 @@ class AnnotationTest(TestCase):
         self.assertTrue("URL_OR_IP" in context.exception.type_set)
         self.assertTrue("NAME" in context.exception.type_set)
 
+    def test_split_annotations_by_subtypes_single_type_no_split(self):
+        '''
+        assert that when we attempt split a merged annotation that is all of a single child type,
+        we return the same merged annotation (self) as a list
+        :return:  [self]
+        '''
+        anns = [AnnotationFactory.from_hutchner(self.sample_hutchner[4])]
+        self.sample_hutchner[5]['start'] = self.sample_hutchner[4]['stop']
+        anns += [AnnotationFactory.from_hutchner(self.sample_hutchner[5])]
+        sorted_anns = sorted(anns, key=lambda x: x.start)
+        merged = MergedAnnotation()
+        for ann in sorted_anns:
+            merged.add_annotation(ann)
+
+        actual = merged.split_annotations_by_subtypes()
+
+        self.assertEqual(len(actual), 1) #a list of the single MergedAnnotation is returned
+        self.assertTrue(isinstance(actual[0], MergedAnnotation))
+        self.assertEqual(actual[0].type, self.sample_hutchner[4]['label'])
 
 


### PR DESCRIPTION
Very rough draft of splitting merged annotations under the following conditions:

1. a single parent type (eg: HOSPITAL and WARD are ADDRESS)
2. different child types  (HOSPITAL AND WARD in same merged annotation)

Note: presently the compmed annotation is still being returned at the front of the list w/ the parent type (it's a unique annotation and span)